### PR TITLE
IssueID #17459 - Create RPM for MapProxy:

### DIFF
--- a/mapproxy-el7/Dockerfile
+++ b/mapproxy-el7/Dockerfile
@@ -1,0 +1,10 @@
+FROM gdal_rpm_el7:latest
+
+ENV version 1.9.0 
+
+RUN yum update -y && yum -y clean all
+RUN yum install -y python-setuptools
+
+WORKDIR "/"
+ADD fpm-mapproxy.sh /fpm-mapproxy.sh
+RUN /fpm-mapproxy.sh

--- a/mapproxy-el7/fpm-mapproxy.sh
+++ b/mapproxy-el7/fpm-mapproxy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# NB: the below disables the python-pyymal dependency since this package is 
+# called PyYAML on CentOS. The disable and then adding of the PyYAML as a 
+# dependency looks strange but had trouble with the PyYAML dependency 
+# without the disable switch.
+
+fpm -v 1.9.0 \
+    --iteration 1.el7 \
+    --epoch 1 \
+    --vendor EDINA \
+    --provides mapproxy \
+    --python-disable-dependency python-pyyaml \
+    --python-disable-dependency PyYAML \
+    -d proj-devel \
+    -d 'python-pillow >= 2' \
+    -d 'python-shapely >= 1.2.0' \
+    -d python-lxml \
+    -d gdal \
+    -d PyYAML \
+    -s python \
+    -t rpm \
+    -n mapproxy \
+    -a x86_64 \
+    MapProxy
+    

--- a/mapproxy-el7/run.sh
+++ b/mapproxy-el7/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t mapproxy_rpm_el7 .
+docker run --rm  -v "$PWD/output":/output mapproxy_rpm_el7 bash -c "cp /*.rpm /output"


### PR DESCRIPTION
Link to issue: https://redmine.edina.ac.uk/issues/17459

A Dockerfile and fpm command to create an RPM for MapProxy. This
Dockerfile requires gdal_rpm_el7 to work.

The resulting mapproxy RPM has dependencies on libraries (e.g. python-shapely)
which are not in the base CentOS repositories, but are in Fedora's EPEL. On
the other hand the libkml and gdal libraries have trouble with the EPEL. One
possible way to install the resulting RPMs is to do:

  sudo yum install -y epel-release
  sudo yum install -y --disablerepo=epel libkml-1.3.0-1.el7.x86_64.rpm gdal-2.1.2-1.el7.x86_64.rpm
  sudo yum install -y mapproxy-1.9.0-1.el7.x86_64.rpm