### PR TITLE
IssueID #17458 - Dockerfile to create a mapcache RPM:

### DIFF
--- a/mapcache-el7/Dockerfile
+++ b/mapcache-el7/Dockerfile
@@ -1,0 +1,40 @@
+FROM mapserver_rpm_el7:latest
+
+RUN yum install -y epel-release swig autoconf cmake httpd-devel libpng-devel libjpeg-devel \
+                   libjpeg-turbo-devel libcurl-devel libgeotiff-devel pcre-devel pixman-devel \
+                   fcgi-devel sqlite-devel libtiff-devel libdb-devel && yum -y clean all
+
+# Require mapserver support
+RUN yum install -y /mapserver*.rpm
+
+# Check out mapcache version 1.4
+RUN git clone git://github.com/mapserver/mapcache.git /root/mapcache
+WORKDIR "/root/mapcache"
+RUN git checkout c5b4683039501a511be7b4e0aafb5ad745d5dbca
+
+# Build with all options enabled.
+# NB: WITH_TIFF_WRITE_SUPPORT has been enabled although there is a warning in the install guide
+#     on it's use (http://www.mapserver.org/mapcache/install.html)
+WORKDIR "/root/mapcache/build"
+RUN cmake ..  -DWITH_PIXMAN=1 \
+              -DWITH_SQLITE=1 \
+              -DWITH_BERKELEY_DB=1 \
+              -DWITH_MEMCACHE=1 \
+              -DWITH_TIFF=1 \
+              -DWITH_TIFF_WRITE_SUPPORT=1 \
+              -DWITH_GEOTIFF=1 \
+              -DWITH_PCRE=1 \
+              -DWITH_MAPSERVER=1 \
+              -DWITH_GEOS=1 \
+              -DWITH_OGR=1 \
+              -DWITH_CGI=1 \
+              -DWITH_FCGI=1 \
+              -DWITH_VERSION_STRING=1 \
+              -DWITH_APACHE=1
+
+RUN make && make install DESTDIR=/tmp/mapcache
+
+WORKDIR "/"
+ADD fpm-mapcache.sh /fpm-mapcache.sh
+ADD after-install.sh /after-install.sh
+RUN /fpm-mapcache.sh

--- a/mapcache-el7/after-install.sh
+++ b/mapcache-el7/after-install.sh
@@ -1,0 +1,2 @@
+echo '/usr/local/lib' > /etc/ld.so.conf.d/mapcache.conf
+ldconfig

--- a/mapcache-el7/fpm-mapcache.sh
+++ b/mapcache-el7/fpm-mapcache.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+fpm -v 1.4 \
+    --iteration 1.el7 \
+    --epoch 1 \
+    --vendor EDINA \
+    --provides mapcache \
+    -d httpd \
+    -d libpng \
+    -d libjpeg \
+    -d libtiff \
+    -d giflib \
+    -d curl \
+    -d sqlite \
+    -d fcgi \
+    -d pixman \
+    -d pcre \
+    -d libdb \
+    -d libgeotiff \
+    -d libkml \
+    -d gdal \
+    -d mapserver \
+    -a x86_64 \
+    -n mapcache \
+    -s dir \
+    -C /tmp/mapcache \
+    -t rpm \
+    --after-install after-install.sh \
+    usr

--- a/mapcache-el7/run.sh
+++ b/mapcache-el7/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t mapcache_rpm_el7 .
+docker run --rm  -v "$PWD/output":/output mapcache_rpm_el7 bash -c "cp /*.rpm /output"


### PR DESCRIPTION
Redmine issue: https://redmine.edina.ac.uk/issues/17458

Dockerfile and associated fpm command to create an RPM for mapcache. This Dockerfile is based on mapserver (which is a dependency). To build the rpm the gdal-el7 and mapserver-el7 rpm's must be build first, followed by the ./run.sh script for this rpm.

All options have been enabled, although please note the warning against using the
WITH_TIFF_WRITE_SUPPORT option in the mapcache install instructions:

  "write support should for now only be enabled on local filesystems,
   with a prefork MPM or FastCGI MapCache install."

(http://www.mapserver.org/mapcache/install.html).