### PR TITLE
Remove old rpms before copying new rpms to output directory:

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ cd <package>
 ```
 
 The generated RPMs will appear in the package `output` folder.
+*Note that all existing .rpm files will be deleted before the new rpm files are written.*

--- a/gdal-el7/run.sh
+++ b/gdal-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t gdal_rpm_el7 .
-docker run --rm  -v "$PWD/output":/output gdal_rpm_el7 bash -c "cp /*.rpm /output"
+docker run --rm  -v "$PWD/output":/output gdal_rpm_el7 bash -c "rm -f /output/*.rpm && cp /*.rpm /output"

--- a/gdal/run.sh
+++ b/gdal/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t gdal_rpm .
-docker run --rm  -v "$PWD/output":/output gdal_rpm bash -c "cp /*.rpm /output"
+docker run --rm  -v "$PWD/output":/output gdal_rpm bash -c "rm -f /output/*.rpm && cp /*.rpm /output"

--- a/git-el7/run.sh
+++ b/git-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t git_el7_rpm .
-docker run --rm  -v "$PWD/output":/output git_el7_rpm bash -c "cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output git_el7_rpm bash -c "rm -f /output/*.rpm && cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"

--- a/git/run.sh
+++ b/git/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t git_rpm .
-docker run --rm  -v "$PWD/output":/output git_rpm bash -c "cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output git_rpm bash -c "rm -f /output/*.rpm && cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"

--- a/mapcache-el7/run.sh
+++ b/mapcache-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t mapcache_rpm_el7 .
-docker run --rm  -v "$PWD/output":/output mapcache_rpm_el7 bash -c "cp /*.rpm /output"
+docker run --rm  -v "$PWD/output":/output mapcache_rpm_el7 bash -c "rm -f /output/*.rpm && cp /*.rpm /output"

--- a/mapproxy-el7/run.sh
+++ b/mapproxy-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t mapproxy_rpm_el7 .
-docker run --rm  -v "$PWD/output":/output mapproxy_rpm_el7 bash -c "cp /*.rpm /output"
+docker run --rm  -v "$PWD/output":/output mapproxy_rpm_el7 bash -c "rm -f /output/*.rpm && cp /*.rpm /output"

--- a/mapserver-el7/run.sh
+++ b/mapserver-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t mapserver_rpm_el7 .
-docker run --rm  -v "$PWD/output":/output mapserver_rpm_el7 bash -c "cp /*.rpm /output"
+docker run --rm  -v "$PWD/output":/output mapserver_rpm_el7 bash -c "rm -f /output/*.rpm && cp /*.rpm /output"

--- a/maven/run.sh
+++ b/maven/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t maven_rpm .
-docker run --rm  -v "$PWD/output":/output maven_rpm bash -c "cp /root/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output maven_rpm bash -c "rm -f /output/*.rpm && cp /root/*.rpm /output"

--- a/mod_jk-el7/run.sh
+++ b/mod_jk-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t mod_jk_el7_rpm .
-docker run --rm  -v "$PWD/output":/output mod_jk_el7_rpm bash -c "cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output mod_jk_el7_rpm bash -c "rm -f /output/*.rpm && cp /root/rpmbuild/RPMS/x86_64/*.rpm /output"

--- a/newrelic_java/run.sh
+++ b/newrelic_java/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t newrelic_java_rpm .
-docker run --rm  -v "$PWD/output":/output newrelic_java_rpm bash -c "cp /root/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output newrelic_java_rpm bash -c "rm -f /output/*.rpm && cp /root/*.rpm /output"

--- a/phantomjs/run.sh
+++ b/phantomjs/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t phantomjs_rpm .
-docker run --rm  -v "$PWD/output":/output phantomjs_rpm bash -c "cp /root/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output phantomjs_rpm bash -c "rm -f /output/*.rpm && cp /root/*.rpm /output"

--- a/postgres-jdbc-el7/run.sh
+++ b/postgres-jdbc-el7/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker build -t pg_jdbc_el7_rpm .
-docker run --rm  -v "$PWD/output":/output pg_jdbc_el7_rpm bash -c "cp /root/*.rpm /output"
+docker run --rm  -v "$PWD/output":/output pg_jdbc_el7_rpm bash -c "rm -f /output/*.rpm && cp /root/*.rpm /output"


### PR DESCRIPTION
Added an "rm -f /output/*.rpm" to remove any older rpms from the output
directory before copying over any newly built rpms.

(no issue was created for this)